### PR TITLE
feat: add copy & type for totp

### DIFF
--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -14,8 +14,10 @@ pub struct UserConfig {
     pub notifications: bool,
     pub copy_user_exit_code: i32,
     pub copy_password_exit_code: i32,
+    pub copy_totp_exit_code: i32,
     pub type_user_exit_code: i32,
     pub type_password_exit_code: i32,
+    pub type_totp_exit_code: i32,
 }
 
 // creates the config file if it does not exist and writes the default config file to it
@@ -37,8 +39,10 @@ pub fn create_config_file(path: PathBuf) -> Result<File, Error> {
         notifications: true,
         copy_user_exit_code: 10,
         copy_password_exit_code: 11,
+        copy_totp_exit_code: 14,
         type_user_exit_code: 12,
         type_password_exit_code: 13,
+        type_totp_exit_code: 15,
     };
 
     // write to the config file with indentation

--- a/src/rbw.rs
+++ b/src/rbw.rs
@@ -2,3 +2,4 @@ pub mod get;
 pub mod list;
 pub mod unlock;
 pub mod user;
+pub mod totp;

--- a/src/rbw/totp.rs
+++ b/src/rbw/totp.rs
@@ -1,0 +1,9 @@
+use crate::command;
+
+// gets the totp
+pub fn totp(name: &String, user: &String) -> String {
+    let args: Vec<String> = vec![String::from("totp"), name.to_owned(), user.to_owned()];
+
+    // rbw totp <name> <user>
+    command::no_std_in("rbw", args).unwrap()
+}

--- a/src/rbw/totp.rs
+++ b/src/rbw/totp.rs
@@ -1,9 +1,9 @@
 use crate::command;
 
 // gets the totp
-pub fn totp(name: &String, user: &String) -> String {
+pub fn totp(name: &String, user: &String) -> Result<String, std::io::Error> {
     let args: Vec<String> = vec![String::from("totp"), name.to_owned(), user.to_owned()];
 
     // rbw totp <name> <user>
-    command::no_std_in("rbw", args).unwrap()
+    command::no_std_in("rbw", args)
 }

--- a/src/rbw/user.rs
+++ b/src/rbw/user.rs
@@ -38,6 +38,8 @@ pub fn get_user(name_choice: String, name_to_users: HashMap<String, Vec<String>>
 
         let password: String = rbw::get::password(&name_choice, &user);
 
+        let totp: String = rbw::totp::totp(&name_choice, &user);
+
         // Copy user only
         if exit_code == cfg.copy_user_exit_code {
             let (result, _exit_code) = command::with_std_in_no_args("wl-copy", user.clone());
@@ -64,12 +66,29 @@ pub fn get_user(name_choice: String, name_to_users: HashMap<String, Vec<String>>
             }
 
             process::exit(0);
+        } else if exit_code == cfg.copy_totp_exit_code {
+            // Copy password only
+            let (result, _exit_code) = command::with_std_in_no_args("wl-copy", totp.clone());
+            let _result = command::no_std_in("cliphist", vec![String::from("delete-query"), password]);
+
+            match result {
+                Ok(_) => {
+                    let _ = notify::send(FRBW_ICON_NAME, FRBW_NAME, String::from("TOTP copied"));
+                }
+                Err(e) => return Err(e),
+            }
+
+            process::exit(0);
         } else if exit_code == cfg.type_user_exit_code {
             command::no_std_in("wtype", vec![user.clone()])?;
 
             process::exit(0);
         } else if exit_code == cfg.type_password_exit_code {
             command::no_std_in("wtype", vec![password.clone()])?;
+
+            process::exit(0);
+        } else if exit_code == cfg.type_totp_exit_code {
+            command::no_std_in("wtype", vec![totp.clone()])?;
 
             process::exit(0);
         }

--- a/src/rbw/user.rs
+++ b/src/rbw/user.rs
@@ -38,7 +38,7 @@ pub fn get_user(name_choice: String, name_to_users: HashMap<String, Vec<String>>
 
         let password: String = rbw::get::password(&name_choice, &user);
 
-        let totp: String = rbw::totp::totp(&name_choice, &user);
+        let totp = rbw::totp::totp(&name_choice, &user);
 
         // Copy user only
         if exit_code == cfg.copy_user_exit_code {
@@ -67,18 +67,23 @@ pub fn get_user(name_choice: String, name_to_users: HashMap<String, Vec<String>>
 
             process::exit(0);
         } else if exit_code == cfg.copy_totp_exit_code {
-            // Copy password only
-            let (result, _exit_code) = command::with_std_in_no_args("wl-copy", totp.clone());
-            let _result = command::no_std_in("cliphist", vec![String::from("delete-query"), password]);
+            // Copy totp only
+            match totp {
+                Ok(t) => {
+                    let (result, _exit_code) = command::with_std_in_no_args("wl-copy", t.clone());
+                    let _result = command::no_std_in("cliphist", vec![String::from("delete-query"), t]);
 
-            match result {
-                Ok(_) => {
-                    let _ = notify::send(FRBW_ICON_NAME, FRBW_NAME, String::from("TOTP copied"));
+                    match result {
+                        Ok(_) => {
+                            let _ = notify::send(FRBW_ICON_NAME, FRBW_NAME, String::from("TOTP copied"));
+                        }
+                        Err(e) => return Err(e),
+                    }
+
+                    process::exit(0);
                 }
                 Err(e) => return Err(e),
             }
-
-            process::exit(0);
         } else if exit_code == cfg.type_user_exit_code {
             command::no_std_in("wtype", vec![user.clone()])?;
 
@@ -88,9 +93,14 @@ pub fn get_user(name_choice: String, name_to_users: HashMap<String, Vec<String>>
 
             process::exit(0);
         } else if exit_code == cfg.type_totp_exit_code {
-            command::no_std_in("wtype", vec![totp.clone()])?;
+            match totp {
+                Ok(t) => {
+                    command::no_std_in("wtype", vec![t.clone()])?;
 
-            process::exit(0);
+                    process::exit(0);
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         wtype::key_in(user, password)


### PR DESCRIPTION
`rbw totp` returns 2fa codes for entries. Add configuration and code to
fetch the totp value for a given entry and copy or type it out depending
on the exit code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Time-based One-Time Password (TOTP) support with clipboard copy and direct entry options for improved 2FA workflows.
  * Introduced configurable exit codes for TOTP copy and TOTP type actions to allow integration with external automation and scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->